### PR TITLE
[FIX] helpdesk_mgmt - message_subscribe() expects a list of ids

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -212,7 +212,7 @@ class HelpdeskTicket(models.Model):
             (msg.get("to") or "") + "," + (msg.get("cc") or "")
         )
         partner_ids = [
-            p
+            p.id
             for p in self.env["mail.thread"]._mail_find_partner_from_emails(
                 email_list, records=ticket, force_create=False
             )
@@ -228,7 +228,7 @@ class HelpdeskTicket(models.Model):
             (msg.get("to") or "") + "," + (msg.get("cc") or "")
         )
         partner_ids = [
-            p
+            p.id
             for p in self.env["mail.thread"]._mail_find_partner_from_emails(
                 email_list, records=self, force_create=False
             )

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -73,3 +73,42 @@ class TestHelpdeskTicket(common.SavepointCase):
             "Helpdesk Ticket: A new ticket can not "
             "have the same number than the origin ticket.",
         )
+
+    def test_helpdesk_ticket_message_new(self):
+        Partner = self.env["res.partner"]
+        Ticket = self.env["helpdesk.ticket"]
+
+        newPartner = Partner.create(
+            {
+                "name": "Jill",
+                "email": "jill@example.com",
+            }
+        )
+        title = "Test Helpdesk ticket message new"
+        msg_id = "0000000000007c50e905cf5b1f2a@example.com"
+        msg_dict = {
+            "message_id": msg_id,
+            "subject": title,
+            "email_from": "Bob <bob@example.com>",
+            "to": "jill@example.com",
+            "cc": "sally@example.com",
+            "recipients": "jill@example.com+sally@example.com",
+            "partner_ids": [newPartner.id],
+            "body": "This the body",
+            "date": "2021-10-10",
+        }
+        try:
+            t = Ticket.message_new(msg_dict)
+        except Exception as error:
+            self.fail("%s: %s" % (type(error), error))
+        self.assertEqual(t.name, title, "The ticket should have the correct title.")
+
+        title = "New title"
+        update_vals = {"name": title}
+        try:
+            t.message_update(msg_dict, update_vals)
+        except Exception as error:
+            self.fail("%s: %s" % (type(error), error))
+        self.assertEqual(
+            t.name, title, "The ticket should have the correct (new) title."
+        )


### PR DESCRIPTION
When a new helpdesk ticket is created from an incoming email or an email reply is sent to an existing ticket the list of followers is updated. This is done by calling the method message_subscribe() with a list of partner ids. The current code tries to call this method with a list of partner objects. Because this method call happens after the ticket is created (for new tickets) but before it runs to completion a new identical ticket is created every time the mail is fetched from the server.