### PR TITLE
[FIX] helpdesk_mgmt: onchange functions should no longer return domains

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -18,10 +18,18 @@ class HelpdeskTicket(models.Model):
         stage_ids = self.env["helpdesk.ticket.stage"].search([])
         return stage_ids
 
+    def _get_user_domain(self):
+        res = "[]"
+        if not self.team_id:
+            return res
+        return "[('id', 'in', self.user_ids)]"
+
     number = fields.Char(string="Ticket number", default="/", readonly=True)
     name = fields.Char(string="Title", required=True)
     description = fields.Html(required=True, sanitize_style=True)
-    user_id = fields.Many2one(comodel_name="res.users", string="Assigned user")
+    user_id = fields.Many2one(
+        comodel_name="res.users", string="Assigned user", domain=_get_user_domain
+    )
     user_ids = fields.Many2many(
         comodel_name="res.users", related="team_id.user_ids", string="Users"
     )
@@ -110,11 +118,6 @@ class HelpdeskTicket(models.Model):
     def _onchange_dominion_user_id(self):
         if self.user_id and self.user_ids and self.user_id not in self.team_id.user_ids:
             self.update({"user_id": False})
-            return {"domain": {"user_id": []}}
-        if self.team_id:
-            return {"domain": {"user_id": [("id", "in", self.user_ids.ids)]}}
-        else:
-            return {"domain": {"user_id": []}}
 
     # ---------------------------------------------------
     # CRUD

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -1,6 +1,6 @@
 import time
 
-from odoo.tests import common
+from odoo.tests import common, new_test_user
 
 
 class TestHelpdeskTicket(common.SavepointCase):
@@ -8,6 +8,7 @@ class TestHelpdeskTicket(common.SavepointCase):
     def setUpClass(cls):
         super(TestHelpdeskTicket, cls).setUpClass()
         helpdesk_ticket = cls.env["helpdesk.ticket"]
+        cls.Team = cls.env["helpdesk.ticket.team"]
         cls.user_admin = cls.env.ref("base.user_root")
         cls.user_demo = cls.env.ref("base.user_demo")
         cls.stage_closed = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
@@ -72,4 +73,76 @@ class TestHelpdeskTicket(common.SavepointCase):
             copy_ticket_number != "/" and old_ticket_number != copy_ticket_number,
             "Helpdesk Ticket: A new ticket can not "
             "have the same number than the origin ticket.",
+        )
+
+    def test_helpdesk_ticket_onchange_team(self):
+        # When the team changes:
+        #    if user_id is in team: do nothing
+        #    if user_id is not in team: remove user_id
+        #    if team exists: domain of user_id is users that are part of the team
+        #    if team is false: domain of user_id is []
+
+        ba_baracus = new_test_user(
+            self.env, login="ba", groups="helpdesk_mgmt.group_helpdesk_manager"
+        )
+        hannibal_smith = new_test_user(
+            self.env, login="hannibal", groups="helpdesk_mgmt.group_helpdesk_manager"
+        )
+        a_team = self.Team.create(
+            {
+                "name": "The A-Team",
+                "user_ids": [(6, 0, [ba_baracus.id, hannibal_smith.id])],
+            }
+        )
+        colonel_decker = new_test_user(
+            self.env, login="decker", groups="helpdesk_mgmt.group_helpdesk_manager"
+        )
+        mp = self.Team.create(
+            {
+                "name": "Military Police",
+                "user_ids": [(6, 0, [colonel_decker.id])],
+            }
+        )
+        self.assertEqual(
+            self.ticket._get_user_domain(),
+            "[]",
+            "User domain should be empty initially",
+        )
+        self.assertFalse(self.ticket.user_id, "User should be false initially")
+
+        self.ticket.user_id = ba_baracus
+        self.ticket.team_id = a_team
+
+        self.assertEqual(self.ticket.team_id, a_team, "The team should be changed")
+        self.assertEqual(
+            self.ticket._get_user_domain(),
+            "[('id', 'in', self.user_ids)]",
+            "Only those users who are in team should be part of the domain",
+        )
+        self.assertItemsEqual(
+            self.ticket.user_ids,
+            a_team.user_ids,
+            "The users list in ticket should be the same as in team",
+        )
+        self.assertEqual(
+            self.ticket.user_id,
+            ba_baracus,
+            "If the current user is in the team, the user shouldn't be removed",
+        )
+
+        self.ticket.team_id = mp
+        # Trigger @onchange manually since it only works with the form view
+        self.ticket._onchange_dominion_user_id()
+
+        self.assertFalse(
+            self.ticket.user_id,
+            "User should be removed if the user is not in the new team",
+        )
+
+        self.ticket.team_id = False
+
+        self.assertEqual(
+            self.ticket._get_user_domain(),
+            "[]",
+            "User domain should be empty if team is not set",
         )


### PR DESCRIPTION
In Odoo 14 onchange() methods that also return domains trigger
deprecation warnings in the logs. Instead the fields that are the
targets of the domain should use the 'domain' keyword argument
in their declarations and specify a method to call. The method
should return a standard odoo search domain string.